### PR TITLE
Update package references to use version ranges

### DIFF
--- a/Adapters/Store/EvDb.Adapters.Store.Abstractions/EvDb.Adapters.Store.Abstractions.csproj
+++ b/Adapters/Store/EvDb.Adapters.Store.Abstractions/EvDb.Adapters.Store.Abstractions.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
-		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<None Include="..\..\..\docs\README.md">
 			<Pack>True</Pack>
 			<PackagePath>\</PackagePath>
 		</None>
+	</ItemGroup>
+	
+	<ItemGroup>
+		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="[8.0.0,)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Adapters/Store/EvDb.Adapters.Store.EvDbRelational/EvDb.Adapters.Store.EvDbRelational.csproj
+++ b/Adapters/Store/EvDb.Adapters.Store.EvDbRelational/EvDb.Adapters.Store.EvDbRelational.csproj
@@ -1,11 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-		<PackageReference Include="Dapper" Version="2.1.35" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Resilience" Version="9.0.0" />
+		<PackageReference Include="Dapper" Version="[2.1.35,)" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -13,7 +8,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />	
+		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="[8.0.0,)" />	
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/Adapters/Store/EvDb.Adapters.Store.EvDbRelationalAdmin/EvDb.Adapters.Store.EvDbRelationalAdmin.csproj
+++ b/Adapters/Store/EvDb.Adapters.Store.EvDbRelationalAdmin/EvDb.Adapters.Store.EvDbRelationalAdmin.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-		<PackageReference Include="Dapper" Version="2.1.35" />
+		<PackageReference Include="Dapper" Version="[2.1.35,)" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -10,7 +9,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="[8.0.0,)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Adapters/Store/EvDb.Adapters.Store.EvDbRelationalCommon/EvDb.Adapters.Store.EvDbRelationalCommon.csproj
+++ b/Adapters/Store/EvDb.Adapters.Store.EvDbRelationalCommon/EvDb.Adapters.Store.EvDbRelationalCommon.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
-		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="[8.0.0,)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Adapters/Store/MongoDB/EvDb.Adapters.Store.EvDbMongoDB/EvDb.Adapters.Store.EvDbMongoDB.csproj
+++ b/Adapters/Store/MongoDB/EvDb.Adapters.Store.EvDbMongoDB/EvDb.Adapters.Store.EvDbMongoDB.csproj
@@ -5,12 +5,12 @@
 	</PropertyGroup>
 	
 	<ItemGroup>
-		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="[8.0.0,)" />
 	</ItemGroup>
 
 
 	<ItemGroup>
-		<PackageReference Include="MongoDB.Driver" Version="3.2.0" />
+		<PackageReference Include="MongoDB.Driver" Version="[3.2.0,)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Adapters/Store/MongoDB/EvDb.Adapters.Store.EvDbMongoDBAdmin/EvDb.Adapters.Store.EvDbMongoDBAdmin.csproj
+++ b/Adapters/Store/MongoDB/EvDb.Adapters.Store.EvDbMongoDBAdmin/EvDb.Adapters.Store.EvDbMongoDBAdmin.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
-	  <PackageReference Include="Npgsql" Version="9.0.1" />
-	  <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.1" />
+	  <PackageReference Include="Npgsql" Version="[9.0.1,)" />
+	  <PackageReference Include="Npgsql.OpenTelemetry" Version="[9.0.1,)" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="[8.0.0,)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Adapters/Store/Postgres/EvDb.Adapters.Store.EvDbPostgres/EvDb.Adapters.Store.EvDbPostgres.csproj
+++ b/Adapters/Store/Postgres/EvDb.Adapters.Store.EvDbPostgres/EvDb.Adapters.Store.EvDbPostgres.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
-		<PackageReference Include="Npgsql" Version="9.0.1" />
-		<PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.1" />
+		<PackageReference Include="Npgsql" Version="[9.0.1,)" />
+		<PackageReference Include="Npgsql.OpenTelemetry" Version="[9.0.1,)" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\EvDb.Adapters.Store.EvDbRelational\EvDb.Adapters.Store.EvDbRelational.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="[8.0.0,)" />
 	</ItemGroup>
 
 

--- a/Adapters/Store/Postgres/EvDb.Adapters.Store.EvDbPostgresAdmin/EvDb.Adapters.Store.EvDbPostgresAdmin.csproj
+++ b/Adapters/Store/Postgres/EvDb.Adapters.Store.EvDbPostgresAdmin/EvDb.Adapters.Store.EvDbPostgresAdmin.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
-	  <PackageReference Include="Npgsql" Version="9.0.1" />
-	  <PackageReference Include="Npgsql.OpenTelemetry" Version="9.0.1" />
+	  <PackageReference Include="Npgsql" Version="[9.0.1,)" />
+	  <PackageReference Include="Npgsql.OpenTelemetry" Version="[9.0.1,)" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\..\EvDb.Adapters.Store.EvDbRelationalAdmin\EvDb.Adapters.Store.EvDbRelationalAdmin.csproj" />
 	  <ProjectReference Include="..\EvDb.Adapters.Store.EvDbPostgres\EvDb.Adapters.Store.EvDbPostgres.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="[8.0.0,)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Adapters/Store/SqlServer/EvDb.Adapters.Store.EvDbSqlServer/EvDb.Adapters.Store.EvDbSqlServer.csproj
+++ b/Adapters/Store/SqlServer/EvDb.Adapters.Store.EvDbSqlServer/EvDb.Adapters.Store.EvDbSqlServer.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
-		<PackageReference Include="Dapper" Version="2.1.35" />
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
+		<PackageReference Include="Dapper" Version="[2.1.35,)" />
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="[5.2.2,)" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="[9.0.0,)" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\..\EvDb.Adapters.Store.EvDbRelational\EvDb.Adapters.Store.EvDbRelational.csproj" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="[8.0.0,)" />
 	</ItemGroup>
 
 

--- a/Adapters/Store/SqlServer/EvDb.Adapters.Store.EvDbSqlServerAdmin/EvDb.Adapters.Store.EvDbSqlServerAdmin.csproj
+++ b/Adapters/Store/SqlServer/EvDb.Adapters.Store.EvDbSqlServerAdmin/EvDb.Adapters.Store.EvDbSqlServerAdmin.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
-		<PackageReference Include="Dapper" Version="2.1.35" />
-		<PackageReference Include="System.Data.SqlClient" Version="4.9.0" />
+		<PackageReference Include="Dapper" Version="[2.1.35,)" />
+		<PackageReference Include="System.Data.SqlClient" Version="[4.9.0,)" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="8.0.0" />
+		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="[8.0.0,)" />
 	</ItemGroup>
 
 

--- a/EvDb.Core/EvDb.Core.csproj
+++ b/EvDb.Core/EvDb.Core.csproj
@@ -1,11 +1,18 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Resilience" Version="9.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Telemetry.Abstractions" Version="9.0.0" />
-		<PackageReference Include="OpenTelemetry.Api" Version="1.10.0" />
-		<ProjectReference Include="..\EvDb.SourceGenerator\EvDb.SourceGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[9.0.0,)" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="[9.0.0,)" />
+		<PackageReference Include="Microsoft.Extensions.Resilience" Version="[9.0.0,)" />
+		<PackageReference Include="Microsoft.Extensions.Telemetry.Abstractions" Version="[9.0.0,)" />
+		<PackageReference Include="OpenTelemetry.Api" Version="[1.10.0,)" />
+	</ItemGroup>
+	
+	<ItemGroup>
+		<PackageReference Include="Generator.Equals" Version="[3.2.0,)" />
+	</ItemGroup>
+	
+	<ItemGroup>
+		<PackageReference Update="Microsoft.SourceLink.GitHub" Version="[8.0.0,)" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -15,18 +22,12 @@
 		</None>
 	</ItemGroup>
 
-	<!--<ItemGroup>
-		<InternalsVisibleTo Include="EvDb.Adapters.Store.EvDbRelational" />
-	</ItemGroup>-->
-
 	 <ItemGroup>
+		<ProjectReference Include="..\EvDb.SourceGenerator\EvDb.SourceGenerator.csproj" ReferenceOutputAssembly="false" OutputItemType="Analyzer" />
 		 <None Include="..\EvDb.SourceGenerator\EvDb.SourceGenerator.csproj" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
 		 <None Include="..\StaticAnalysis\EvDb.Core.Analyzer\EvDb.Core.Analyzer.csproj" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
 		 <None Include="..\StaticAnalysis\EvDb.Core.CodeFixes\EvDb.Core.CodeFixes.csproj" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
 	 </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Generator.Equals" Version="3.2.0" />
-	</ItemGroup>
 </Project>
 


### PR DESCRIPTION
- Changed package references in multiple project files to version ranges for improved flexibility and compatibility.
- Added `Generator.Equals` package reference in `EvDb.Core.csproj`.
- Cleaned up project files by removing unnecessary lines and comments.