### PR TITLE
Refactor outbox collection naming format

### DIFF
--- a/Adapters/Store/MongoDB/EvDb.Adapters.Store.EvDbMongoDB/Helpers/CollectionsSetup.cs
+++ b/Adapters/Store/MongoDB/EvDb.Adapters.Store.EvDbMongoDB/Helpers/CollectionsSetup.cs
@@ -58,7 +58,6 @@ public sealed class CollectionsSetup : IDisposable, IAsyncDisposable
 
     #region Ctor
 
-
     private CollectionsSetup(
                     ILogger logger,
                     MongoClient client,
@@ -71,7 +70,7 @@ public sealed class CollectionsSetup : IDisposable, IAsyncDisposable
         _creationMode = creationMode;
         _collectionPrefix = storageContext.CalcCollectionPrefix();
         _db = _client.GetDatabase(storageContext.DatabaseName);
-        _outboxCollectionFormat = $$"""{{_collectionPrefix}}{0}_{{OUTBOX_SUFFX}}""";
+        _outboxCollectionFormat = $$"""{{_collectionPrefix}}{0}{1}{{OUTBOX_SUFFX}}""";
         EventsCollectionTask = CreateEventsCollectionAsync();
         SnapshotsCollectionTask = CreateSnapshotsCollectionAsync();
     }
@@ -136,9 +135,12 @@ public sealed class CollectionsSetup : IDisposable, IAsyncDisposable
                                                             EvDbShardName shardName,
                                                             CancellationToken cancellation = default)
     {
+        string separator = "_";
         if (string.Compare(shardName.Value, OUTBOX_SUFFX, true) == 0)
             shardName = string.Empty;
-        string collectionName = string.Format(_outboxCollectionFormat, shardName);
+        if(string.IsNullOrEmpty(shardName.Value))
+            separator = "";
+        string collectionName = string.Format(_outboxCollectionFormat, shardName, separator);
         IMongoCollection<BsonDocument> outboxCollection =
                             await CreateOutboxCollectionIfNotExistsAsync(collectionName, cancellation);
         return outboxCollection;

--- a/Tests/EvDb.IntegrationTests/Helpers/MongoOutboxTestHelper.cs
+++ b/Tests/EvDb.IntegrationTests/Helpers/MongoOutboxTestHelper.cs
@@ -26,9 +26,12 @@ internal static class MongoOutboxTestHelper
         string databaseName = storageContext.DatabaseName;
         var db = client.GetDatabase(databaseName);
 
+        string separator = "_";
         if (shard.Value == "outbox")
             shard = string.Empty;
-        var outboxCollectionFormat = $"{collectionPrefix}{shard}_outbox";
+        if (string.IsNullOrEmpty(shard.Value))
+            separator = "";
+        var outboxCollectionFormat = $"{collectionPrefix}{shard}{separator}outbox";
         var collection = db.GetCollection<BsonDocument>(outboxCollectionFormat);
 
         var projection = Builders<BsonDocument>.Projection


### PR DESCRIPTION
Updated the `_outboxCollectionFormat` in `CollectionsSetup` to include a separator based on `shardName`. Enhanced the `CreateOutboxCollectionIfNotExistsAsync` method to handle empty `shardName` values for more flexible collection name generation.

Similar adjustments were made in `MongoOutboxTestHelper` to ensure consistent naming conventions across the codebase.